### PR TITLE
Remove unnecessary fields.

### DIFF
--- a/src/stackmap_checker/call_stack_state.h
+++ b/src/stackmap_checker/call_stack_state.h
@@ -52,8 +52,6 @@ typedef struct CallStackState {
 typedef struct RestoredStackSegment {
     uint64_t start_addr;
     uint64_t total_size;
-    uint64_t main_bp;
-    uint64_t rsp;
 } restored_segment_t;
 
 /*


### PR DESCRIPTION
This removes two fields from the `RestoredStackSegment` struct, since they don't seem to be used anywhere.